### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php" : ">=5.4.0",
-        "symfony/yaml": "2.5.4"
+        "symfony/yaml": "~2.5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "4.2.*"


### PR DESCRIPTION
Updated symfony yaml requirement to use the composer about (~) operator, since 2.5.5 is the latest stable.

All phpunit tests still pass after the change.
